### PR TITLE
No longer build on schedule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,10 @@ on:
     paths-ignore:
       - "**.md"
   push:
+    branches:
+      - master
     paths-ignore:
       - "**.md"
-  schedule:
-    - cron: 0 0 * * *
 
 jobs:
   plugin_test:
@@ -18,6 +18,28 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v1.1.0
         with:
           command: op --version
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          path: 1password-cli
+      - name: Move 1password-cli plugin to plugins dir
+        run: |
+          mkdir -p ${HOME}/.asdf/plugins/
+          mv 1password-cli ${HOME}/.asdf/plugins/
+      - name: Run 1password-cli specific tests
+        run: |
+          echo "Trying to list all versions of 1password-cli"
+          asdf list all 1password-cli
+          echo "Will try to install 1password-cli 1.11.0 (Last version with amd64 for MacOS)"
+          asdf install 1password-cli 1.11.0
+          echo "Will try to install 1password-cli 1.11.1 (First version with universal for MacOS)"
+          asdf install 1password-cli 1.11.1
+          echo "Setting 1password-cli version 1.11.0 as the default value in ~/.tool-versions"
+          echo '1password-cli 1.11.0' > ~/.tool-versions
+          op --version 2>&1 | grep '1.11.0'
+          echo "Setting 1password-cli version 1.11.1 as the default value in ~/.tool-versions"
+          echo '1password-cli 1.11.1' > ~/.tool-versions
+          op --version 2>&1 | grep '1.11.1'

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -37,10 +37,11 @@ download_release() {
     darwin)
       ext="pkg"
       filter_platform="apple\|darwin"
+      arch="${arch}\|universal"
       ;;
   esac
 
-  url=$(curl -s https://app-updates.agilebits.com/product_history/CLI | grep ${version} | grep ${filter_platform} | grep ${arch} | sed -e 's/<a /\n<a /g' | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' | sed '/^[[:space:]]*$/d')
+  url=$(curl -s https://app-updates.agilebits.com/product_history/CLI | grep "${version}" | grep "${filter_platform}" | grep "${arch}" | sed -e 's/<a /\n<a /g' | sed -e 's/<a .*href=['"'"'"]//' -e 's/["'"'"'].*$//' -e '/^$/ d' | sed '/^[[:space:]]*$/d' | grep -o "https.*$")
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename.${ext}" -C - "$url" || fail "Could not download $url"
 }
@@ -60,9 +61,8 @@ install_version() {
     case $platform in
       darwin)
         ext="pkg"
-        sudo installer -pkg "$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.pkg" -target "$install_path/bin"
-        sudo mv "/usr/local/bin/op" "$install_path/bin/"
-        sudo chown -R $USER:$USER "$install_path/bin/*"
+        pkgutil --expand "${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}-${ASDF_INSTALL_VERSION}.${ext}" "${ASDF_DOWNLOAD_PATH}/extracted/"
+        tar -xzf "$ASDF_DOWNLOAD_PATH/extracted/op.${ext}/Payload" -C "$install_path/bin"
         ;;
       *)
         cp -R "$ASDF_DOWNLOAD_PATH/." "$install_path/bin"


### PR DESCRIPTION
- asdf-vm/actions/plugin-test version 1.1.0
- add support for universal arch in MacOS
- MacOS `build` passes and tests pass as well
