### PR TITLE
Fix macOS downloads of 2.20 and later

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,23 @@ jobs:
         run: |
           echo "Trying to list all versions of 1password-cli"
           asdf list all 1password-cli
-          echo "Will try to install 1password-cli 1.11.0 (Last version with amd64 for MacOS)"
+          echo "Will try to install 1password-cli 1.11.0 (Last version with amd64 for macOS)"
           asdf install 1password-cli 1.11.0
-          echo "Will try to install 1password-cli 1.11.1 (First version with universal for MacOS)"
+          echo "Will try to install 1password-cli 1.11.1 (First version with universal for macOS)"
           asdf install 1password-cli 1.11.1
+          echo "Will try to install 1password-cli 2.0.0 (First 2.0 version)"
+          asdf install 1password-cli 2.0.0
+          echo "Will try to install 1password-cli 2.2.0 (First version with zip and pkg versions for macOS)"
+          asdf install 1password-cli 2.2.0
           echo "Setting 1password-cli version 1.11.0 as the default value in ~/.tool-versions"
           echo '1password-cli 1.11.0' > ~/.tool-versions
           op --version 2>&1 | grep '1.11.0'
           echo "Setting 1password-cli version 1.11.1 as the default value in ~/.tool-versions"
           echo '1password-cli 1.11.1' > ~/.tool-versions
           op --version 2>&1 | grep '1.11.1'
+          echo "Setting 1password-cli version 2.0.0 as the default value in ~/.tool-versions"
+          echo '1password-cli 2.0.0' > ~/.tool-versions
+          op --version 2>&1 | grep '2.0.0'
+          echo "Setting 1password-cli version 2.2.0 as the default value in ~/.tool-versions"
+          echo '1password-cli 2.2.0' > ~/.tool-versions
+          op --version 2>&1 | grep '2.2.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1.1.0
+        uses: asdf-vm/actions/plugin-test@v2
         with:
           command: op --version
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: 1password-cli
       - name: Move 1password-cli plugin to plugins dir

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run ShellCheck
         run: shellcheck -x bin/*
 
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install shfmt
         run: brew install shfmt
       - name: Run shfmt

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-shellcheck 0.7.2
+shellcheck 0.9.0
 shfmt 3.2.4

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -60,6 +60,9 @@ download_release() {
   # Limit to architecture ${arch}
   url=$(echo "${url}" | grep "${arch}")
 
+  # Limit to trailing extension \.${ext} (not /${ext}/ in path)
+  url=$(echo "${url}" | grep "\.${ext}")
+
   # Ensure each link is on its own line
   url=$(echo "${url}" | sed -e "s/<a /\n<a /g")
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -77,9 +77,12 @@ download_release() {
   url=$(echo "${url}" | grep -o "https.*$")
 
   # Expect only one line
-  if [[ $(echo "$url" | wc -l | tr -d ' ') != 1 ]]; then
+  if [[ $(echo "$url" | wc -l | tr -d ' ') -gt 1 ]]; then
     echo "Unable to winnow down to a single URL:"
     echo "$url"
+    exit 1
+  elif [[ ${url} == "" ]]; then
+    echo "Failed to extract a URL for version ${version}"
     exit 1
   fi
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -64,6 +64,7 @@ download_release() {
   url=$(echo "${url}" | grep "\.${ext}")
 
   # Ensure each link is on its own line
+  # shellcheck disable=SC2001 # (bash 3.2.x parameter expansion can't handle newlines)
   url=$(echo "${url}" | sed -e "s/<a /\n<a /g")
 
   # Strip off HTML
@@ -109,7 +110,7 @@ install_version() {
       *)
         cp -R "$ASDF_DOWNLOAD_PATH/." "$install_path/bin"
         is_exists=$(program_exists)
-        echo $is_exists
+        echo "$is_exists"
         if [ "$is_exists" != 0 ]; then
           gpg --keyserver hkps://keyserver.ubuntu.com:443 --receive-keys "$TOOL_GPG_KEY"
           gpg --verify "$install_path/bin/op.sig" "$install_path/bin/op" || fail "asdf-$TOOL_NAME download file verify fail with GPG."


### PR DESCRIPTION
This fixes https://github.com/NeoHsu/asdf-1password-cli/issues/7, by adding a test for the desired filename extension. At version 2.20, the op tool added a darwin zip distribution which resulted in multiple URLs falling through to curl, which curl didn't appreciate.

I also broke up the long chain of filter steps into something easier to describe and pull apart in testing. I like a good one-liner, but this is fragile, and should be written with debugging in mind.